### PR TITLE
Improve cart UX and order persistence

### DIFF
--- a/cart-script.js
+++ b/cart-script.js
@@ -278,7 +278,19 @@ Siparişi onaylıyor musunuz?
     if (confirm(message)) {
         // Başarı modalını göster
         showSuccessModal();
-        
+
+        const history = JSON.parse(localStorage.getItem('orderHistory') || '[]');
+        const newOrder = {
+            id: Math.floor(Math.random() * 90000) + 10000,
+            status: 'in-progress',
+            items: cart.map(item => `${item.quantity}x ${item.name}`).join(', '),
+            date: new Date().toLocaleString('tr-TR'),
+            total: cartTotal
+        };
+        history.unshift(newOrder);
+        localStorage.setItem('orderHistory', JSON.stringify(history));
+        localStorage.setItem('redirectToOrders', 'true');
+
         // Sepeti temizle
         cart = [];
         saveCartToStorage();

--- a/cart-styles.css
+++ b/cart-styles.css
@@ -2,6 +2,10 @@
    CART PAGE STYLES
    ===================================== */
 
+body {
+    overflow-y: auto;
+}
+
 /* ===== CART CONTAINER ===== */
 .cart-container {
     max-width: 1200px;

--- a/index.html
+++ b/index.html
@@ -73,7 +73,9 @@
                 <div class="location">Aksaray</div>
                 <div class="header-right">
     <button id="themeToggle" class="theme-toggle-btn" aria-label="Tema Degistir">🌙</button>
-    <button id="cartButton" class="cart-btn" aria-label="Sepetim">🛒</button>
+    <button id="cartButton" class="cart-btn" aria-label="Sepetim">🛒
+        <span id="cartCounter" class="cart-badge">0</span>
+    </button>
     <div class="user-avatar" id="userAvatar">👤</div>
             </div>
             </div>

--- a/script.js
+++ b/script.js
@@ -47,6 +47,17 @@ function loadCartFromStorage() {
     updateCartDisplay();
 }
 
+function saveOrderHistoryToStorage() {
+    localStorage.setItem('orderHistory', JSON.stringify(orderHistory));
+}
+
+function loadOrderHistoryFromStorage() {
+    const storedHistory = localStorage.getItem('orderHistory');
+    if (storedHistory) {
+        orderHistory = JSON.parse(storedHistory);
+    }
+}
+
 // ===== NAVIGATION SYSTEM =====
 
 /**
@@ -330,6 +341,7 @@ function completeOrder() {
     
     // Sipariş geçmişine ekle
     orderHistory.unshift(newOrder);
+    saveOrderHistoryToStorage();
     
     alert('🎉 Siparişiniz alındı!\n\nSipariş No: #' + newOrder.id + '\nKuryemiz yolda, 8 dakika içinde kapınızda olacak!');
     
@@ -757,6 +769,7 @@ function logAppInfo() {
 function initializeApp() {
     initializeThemeToggle();
     loadCartFromStorage();
+    loadOrderHistoryFromStorage();
     const cartBtn = document.getElementById('cartButton');
     if (cartBtn) {
         cartBtn.addEventListener('click', function () {
@@ -781,9 +794,14 @@ function initializeApp() {
     
     // Konsol mesajları
     logAppInfo();
-    
-    // Ana sayfayı göster
-    navigateToPage('home');
+
+    const redirect = localStorage.getItem('redirectToOrders');
+    if (redirect) {
+        navigateToPage('orders');
+        localStorage.removeItem('redirectToOrders');
+    } else {
+        navigateToPage('home');
+    }
 }
 
 // ===== EVENT LISTENERS =====
@@ -796,12 +814,7 @@ document.addEventListener('DOMContentLoaded', initializeApp);
 /**
  * Sayfa yenilenmeden önce uyarı göster (sepette ürün varsa)
  */
-window.addEventListener('beforeunload', function(e) {
-    if (cart.length > 0) {
-        e.preventDefault();
-        e.returnValue = 'Sepetinizde ürünler var. Sayfayı kapatmak istediğinizden emin misiniz?';
-    }
-});
+
 
 /**
  * Klavye kısayolları

--- a/styles.css
+++ b/styles.css
@@ -1241,6 +1241,7 @@ body.light-mode {
 }
 
 .cart-btn {
+    position: relative;
     background: transparent;
     border: 2px solid var(--border-color);
     border-radius: 50%;
@@ -1268,6 +1269,23 @@ body.light-mode {
 .cart-btn:hover {
     background: var(--surface-light);
     transform: scale(1.1);
+}
+
+.cart-badge {
+    position: absolute;
+    top: -6px;
+    right: -6px;
+    background: linear-gradient(135deg, var(--primary-orange), var(--primary-orange-light));
+    color: #fff;
+    border-radius: 50%;
+    padding: 2px 6px;
+    font-size: 12px;
+    font-weight: 700;
+    display: none;
+}
+
+.cart-badge.visible {
+    display: block;
 }
 
 .cart-page {


### PR DESCRIPTION
## Summary
- add a numeric badge to the cart button
- allow scroll on the cart page
- store order history in `localStorage`
- remove unload warning
- redirect to orders page after checkout

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6852cfb748e8832282f639a903857083